### PR TITLE
Update s/all.styl

### DIFF
--- a/s/all.styl
+++ b/s/all.styl
@@ -243,7 +243,7 @@ A:hover
 
     .page_post &
       text-shadow: -1px 0 $distant_bg, 1px 0 $distant_bg, -2px -1px $distant_bg, 2px -1px $distant_bg,
-                    0 -1px $distant_bg, 0 -2px $distant_bg, 0 -3px $distant_bg, 0 -4px $distant_bg, 0 -5px $distant_bg, 0 -6px $distant_bg
+                    0 -1px $distant_bg, 0 -2px $distant_bg, 0 -3px $distant_bg, 0 -4px $distant_bg, 0 -5px $distant_bg, 0 -6px $distant_bg, 0 -7px $distant_bg
 
   .feedback > &,
   .published > &,


### PR DESCRIPTION
Small update to link hover style for better display on retina.
Here what I see on retina macbook on hover:
![kizu](https://f.cloud.github.com/assets/741973/75744/33e1fd42-60d4-11e2-8e4a-255eb152cf45.png)
